### PR TITLE
Improved type definitions for the maching functions

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -7,7 +7,6 @@ import {AnythingMatcher} from "./matcher/type/AnythingMatcher";
 import {BetweenMatcher} from "./matcher/type/BetweenMatcher";
 import {DeepEqualMatcher} from "./matcher/type/DeepEqualMatcher";
 import {NotNullMatcher} from "./matcher/type/NotNullMatcher";
-import {Matcher} from "./matcher/type/Matcher";
 import {StrictEqualMatcher} from "./matcher/type/StrictEqualMatcher";
 export {Captor} from "./Captor";
 
@@ -35,11 +34,11 @@ export function resetCalls<T>(mock: T): void {
     (mock as any).__tsmockitoMocker.resetCalls();
 }
 
-export function anyNumber(): any {
+export function anyNumber(): number {
     return new AnyNumberMatcher() as any;
 }
 
-export function anyString(): any {
+export function anyString(): string {
     return new AnyStringMatcher() as any;
 }
 
@@ -47,18 +46,18 @@ export function anything(): any {
     return new AnythingMatcher() as any;
 }
 
-export function between(min: number, max: number): any {
+export function between(min: number, max: number): number {
     return new BetweenMatcher(min, max) as any;
 }
 
-export function deepEqual(expectedValue: any): any {
-    return new DeepEqualMatcher(expectedValue);
+export function deepEqual<T>(expectedValue: T): T {
+    return new DeepEqualMatcher(expectedValue) as any;
 }
 
 export function notNull(): any {
     return new NotNullMatcher() as any;
 }
 
-export function strictEqual(expectedValue: any): Matcher {
-    return new StrictEqualMatcher(expectedValue);
+export function strictEqual<T>(expectedValue: T): T {
+    return new StrictEqualMatcher(expectedValue) as any;
 }


### PR DESCRIPTION
This pull request adresses the following issue:
```typescript
interface SomeType {
  a:number;
}

class SomeClass {
  set(some:SomeType):string {

  }
}
const someMock = mock(SomeClass);

 // this will cause a compilation error (currently is accepted by the compiler):
when(someMock.set(deepEqual(['wrong', 'type']))).thenReturn('s'); // error

// this will be accepted be the compiler:
when(someMock.set(deepEqual({a: 12}))).thenReturn('s');  // ok
```