### PR TITLE
Type mocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,70 @@ foo.getBar(3); // MultipleMatchersMatchSameStubError will be thrown, two matcher
 
 ```
 
+### Mocking types
+
+You can mock abstract classes
+
+``` typescript
+const mockedFoo = mock(SampleAbstractClass);
+const foo = instance(mockedFoo);
+
+abstract class SampleAbstractClass {
+    dependency:Bar;
+
+    public get sampleString(): string {
+        return "sampleString";
+    }
+
+    public sampleMethod(): number {
+        return 4;
+    }
+
+    public get twoPlusTwo(): number {
+        return this.dependency.sumTwoNumbers(2, 2);
+    }
+
+    public set twoPlusTwo(value: number) {
+        this.dependency.sumTwoNumbers(value, 0);
+    }
+}
+
+```
+
+You can also mock generic classes, but note that the type parameter can't be set
+
+``` typescript
+
+const mockedFoo = mock(SampleGeneric);
+const foo = instance(mockedFoo);
+
+interface SampleInterface {
+    dependency:Bar;
+
+    sampleMethod(): number;
+}
+
+class SampleGeneric<T> {
+    dependency: Bar;
+
+    public get sampleString(): string {
+        return "sampleString";
+    }
+
+    public sampleMethod(): number {
+        return 4;
+    }
+
+    public get twoPlusTwo(): number {
+        return this.dependency.sumTwoNumbers(2, 2);
+    }
+
+    public set twoPlusTwo(value: number) {
+        this.dependency.sumTwoNumbers(value, 0);
+    }
+}
+```
+
 ### Thanks
 
 * Szczepan Faber (https://www.linkedin.com/in/szczepiq) 

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -26,7 +26,7 @@ import {MethodStubVerificator} from "./MethodStubVerificator";
 import {MethodToStub} from "./MethodToStub";
 import {Mocker} from "./Mock";
 
-export function mock<T>(clazz: { new(...args: any[]): T; }): T {
+export function mock<T>(clazz: { new(...args: any[]): T; } | (Function & { prototype: T }) ): T {
     return new Mocker(clazz).getMock();
 }
 

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -1,0 +1,173 @@
+import {mock, instance, when} from "../src/ts-mockito";
+import {Bar} from "./utils/Bar";
+import {MethodToStub} from "../src/MethodToStub";
+
+describe("mocking", () => {
+    describe("mocking abstract class", () => {
+        let mockedFoo: SampleAbstractClass;
+        let foo: SampleAbstractClass;
+
+        it("does not execute getter or setter code (not throwing null pointer exception)", () => {
+            // given
+
+            // when
+            mockedFoo = mock(SampleAbstractClass);
+            foo = instance(mockedFoo);
+
+            // then
+
+        });
+
+        it("does create own property descriptors on mock", () => {
+            // given
+
+            // when
+            mockedFoo = mock(SampleAbstractClass);
+
+            // then
+            expect(<any>mockedFoo.twoPlusTwo instanceof MethodToStub).toBe(true);
+        });
+
+        it("does create own property descriptors on instance", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            foo = instance(mockedFoo);
+
+            // when
+            when(mockedFoo.twoPlusTwo).thenReturn(42);
+
+            // then
+            expect(foo.twoPlusTwo).toBe(42);
+        });
+
+        it("does create inherited property descriptors on mock", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            foo = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(<any>mockedFoo.sampleString instanceof MethodToStub).toBe(true);
+        });
+
+        it("does create inherited property descriptors on instance", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            foo = instance(mockedFoo);
+
+            // when
+            when(mockedFoo.sampleString).thenReturn("42");
+
+            // then
+            expect(foo.sampleString).toBe("42");
+        });
+    });
+
+    describe("mocking generic class", () => {
+        let mockedFoo: SampleGeneric<SampleInterface>;
+        let foo: SampleGeneric<SampleInterface>;
+
+        it("does not execute getter or setter code (not throwing null pointer exception)", () => {
+            // given
+
+            // when
+            mockedFoo = mock(SampleGeneric);
+            foo = instance(mockedFoo);
+
+            // then
+
+        });
+
+        it("does create own property descriptors on mock", () => {
+            // given
+
+            // when
+            mockedFoo = mock(SampleGeneric);
+
+            // then
+            expect(<any>mockedFoo.twoPlusTwo instanceof MethodToStub).toBe(true);
+        });
+
+        it("does create own property descriptors on instance", () => {
+            // given
+            mockedFoo = mock(SampleGeneric);
+            foo = instance(mockedFoo);
+
+            // when
+            when(mockedFoo.twoPlusTwo).thenReturn(42);
+
+            // then
+            expect(foo.twoPlusTwo).toBe(42);
+        });
+
+        it("does create inherited property descriptors on mock", () => {
+            // given
+            mockedFoo = mock(SampleGeneric);
+            foo = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(<any>mockedFoo.sampleString instanceof MethodToStub).toBe(true);
+        });
+
+        it("does create inherited property descriptors on instance", () => {
+            // given
+            mockedFoo = mock(SampleGeneric);
+            foo = instance(mockedFoo);
+
+            // when
+            when(mockedFoo.sampleString).thenReturn("42");
+
+            // then
+            expect(foo.sampleString).toBe("42");
+        });
+    });
+});
+
+abstract class SampleAbstractClass {
+    dependency:Bar;
+
+    public get sampleString(): string {
+        return "sampleString";
+    }
+
+    public sampleMethod(): number {
+        return 4;
+    }
+
+    public get twoPlusTwo(): number {
+        return this.dependency.sumTwoNumbers(2, 2);
+    }
+
+    public set twoPlusTwo(value: number) {
+        this.dependency.sumTwoNumbers(value, 0);
+    }
+}
+
+interface SampleInterface {
+    dependency:Bar;
+
+    sampleMethod(): number;
+}
+
+class SampleGeneric<T> {
+    dependency: Bar;
+
+    public get sampleString(): string {
+        return "sampleString";
+    }
+
+    public sampleMethod(): number {
+        return 4;
+    }
+
+    public get twoPlusTwo(): number {
+        return this.dependency.sumTwoNumbers(2, 2);
+    }
+
+    public set twoPlusTwo(value: number) {
+        this.dependency.sumTwoNumbers(value, 0);
+    }
+}


### PR DESCRIPTION
### Overview
This PR fixes #25. I had to made this patch to use this feature in my project. I expected that all the test tools are ready for typescript though.

### Testing
Anyway, for testing, I copied the test file `mocking.getter.spec.ts` and replaced mock targets with each of abstract class and generic class. All passed. But I didn't try using this actually in my project yet.
```
Chrome 60.0.3112 (Windows 10 0.0.0): Executed 140 of 140 SUCCESS (31.007 secs / 10.527 secs)
```

### Implementation
I added a small feature that allows the parameter of abstract and generic classes on `mock()`


### Open Issues
There's an open issue: we can't accept interfaces and generic classes with type parameters. For interfaces, I'm not sure but typescript says that "Oh man, you can't use type as a value! Stop hacking me :p" And for generic classes, we need a feature on typescript where [generic of generic is available](https://github.com/Microsoft/TypeScript/issues/1213), which is still on discussion.

### Closing
Please review this PR kindly, and merge it if any issue isn't found.