### PR TITLE
Allow to use other matchers in deepEqual

### DIFF
--- a/src/matcher/type/DeepEqualMatcher.ts
+++ b/src/matcher/type/DeepEqualMatcher.ts
@@ -7,13 +7,14 @@ export class DeepEqualMatcher extends Matcher {
     }
 
     match(value: any): boolean {
-        return _.isEqualWith(this.expectedValue, value, (expected, actual) => {
-            if (expected instanceof Matcher) {
-                return expected.match(actual);
-            }
+        return _.isEqualWith(this.expectedValue, value,
+            (expected: any, actual: any): boolean => {
+                if (expected instanceof Matcher) {
+                    return expected.match(actual);
+                }
 
-            return undefined;
-        });
+                return undefined;
+            });
     }
 
     toString(): string {

--- a/src/matcher/type/DeepEqualMatcher.ts
+++ b/src/matcher/type/DeepEqualMatcher.ts
@@ -7,7 +7,13 @@ export class DeepEqualMatcher extends Matcher {
     }
 
     match(value: any): boolean {
-        return _.isEqual(this.expectedValue, value);
+        return _.isEqualWith(this.expectedValue, value, (expected, actual) => {
+            if (expected instanceof Matcher) {
+                return expected.match(actual);
+            }
+
+            return undefined;
+        });
     }
 
     toString(): string {

--- a/test/matcher/type/DeepEqualMatcher.spec.ts
+++ b/test/matcher/type/DeepEqualMatcher.spec.ts
@@ -1,5 +1,6 @@
 import {Matcher} from "../../../src/matcher/type/Matcher";
-import {anything, deepEqual} from "../../../src/ts-mockito";
+import {deepEqual} from "../../../src/ts-mockito";
+import {anyString} from "../../../src/ts-mockito";
 
 describe('DeepEqualMatcher', () => {
     describe('checking if two different instances of same number matches', () => {
@@ -63,10 +64,10 @@ describe('DeepEqualMatcher', () => {
     });
 
     describe('checking if expected value has Matcher as a value', () => {
-        it('delegates to the matcher', () => {
+        it('returns true if matcher returns true', () => {
             // given
-            const firstValue = {a: 1, b: anything()};
-            const secondValue = {a: 1, b: 2};
+            const firstValue = {a: 1, b: anyString()};
+            const secondValue = {a: 1, b: '2'};
             let testObj: Matcher = deepEqual(firstValue);
 
             // when
@@ -74,6 +75,19 @@ describe('DeepEqualMatcher', () => {
 
             // then
             expect(result).toBeTruthy();
+        });
+
+        it('returns false if matcher returns false', () => {
+            // given
+            const firstValue = {a: 1, b: anyString()};
+            const secondValue = {a: 1, b: 2};
+            let testObj: Matcher = deepEqual(firstValue);
+
+            // when
+            const result = testObj.match(secondValue);
+
+            // then
+            expect(result).toBeFalsy();
         });
     });
 });

--- a/test/matcher/type/DeepEqualMatcher.spec.ts
+++ b/test/matcher/type/DeepEqualMatcher.spec.ts
@@ -1,5 +1,5 @@
 import {Matcher} from "../../../src/matcher/type/Matcher";
-import {deepEqual} from "../../../src/ts-mockito";
+import {anything, deepEqual} from "../../../src/ts-mockito";
 
 describe('DeepEqualMatcher', () => {
     describe('checking if two different instances of same number matches', () => {
@@ -59,6 +59,21 @@ describe('DeepEqualMatcher', () => {
 
             // then
             expect(result).toBeFalsy();
+        });
+    });
+
+    describe('checking if expected value has Matcher as a value', () => {
+        it('delegates to the matcher', () => {
+            // given
+            const firstValue = {a: 1, b: anything()};
+            const secondValue = {a: 1, b: 2};
+            let testObj: Matcher = deepEqual(firstValue);
+
+            // when
+            const result = testObj.match(secondValue);
+
+            // then
+            expect(result).toBeTruthy();
         });
     });
 });


### PR DESCRIPTION
Similar to how jasmine allows to use `any` or `anything`, it would be quite useful to match only a part of the object in `deepEqual`.