### PR TITLE
Implement mocking for properties without getters by using es6 Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ let foo:Foo = instance(mockedFoo);
 console.log(foo.sampleGetter);
 ```
 
+### Stubbing property values that have no getters
+
+Syntax is the same as with getter values.
+
+Please note, that stubbing properties that don't have getters only works if [Proxy](http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-objects) object is available (ES6).
+
 ### Call count verification
 
 ``` typescript

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -30,7 +30,23 @@ export class Mocker {
     }
 
     public getMock(): any {
-        return this.mock;
+        if (typeof Proxy === "undefined") {
+            return this.mock;
+        }
+
+        return new Proxy(this.mock, this.createCatchAllHandlerForRemainingPropertiesWithoutGetters());
+    }
+
+    public createCatchAllHandlerForRemainingPropertiesWithoutGetters(): ProxyHandler<any> {
+        return {
+            get: (target: any, name: PropertyKey) => {
+                const hasMethodStub = name in target;
+                if (!hasMethodStub) {
+                    this.createPropertyStub(name.toString());
+                    this.createInstancePropertyDescriptorListener(name.toString(), {}, this.clazz.prototype);
+                }
+                return target[name];
+        }};
     }
 
     public reset(): void {

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -44,7 +44,13 @@ export function when<T>(method: T): MethodStubSetter<T> {
 }
 
 export function instance<T>(mockedValue: T): T {
-    return (mockedValue as any).__tsmockitoInstance as T;
+    const tsmockitoInstance = (mockedValue as any).__tsmockitoInstance as T;
+    if (typeof Proxy === "undefined") {
+        return tsmockitoInstance;
+    }
+
+    const tsmockitoMocker = (mockedValue as any).__tsmockitoMocker as Mocker;
+    return new Proxy(tsmockitoInstance as any, tsmockitoMocker.createCatchAllHandlerForRemainingPropertiesWithoutGetters());
 }
 
 export function capture<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>(method: (a: T0, b: T1, c: T2, d: T3, e: T4, f: T5, g: T6, h: T7, i: T8, j: T9) => any): ArgCaptor10<T0, T1, T2, T3, T4, T5, T6, T7, T8, T9>;

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "lib": [
       "es5",
+      "es6",
       "dom"
     ],
     "types": [

--- a/test/mocking.properties.spec.ts
+++ b/test/mocking.properties.spec.ts
@@ -1,0 +1,63 @@
+import {MethodToStub} from "../src/MethodToStub";
+import {instance, mock, verify, when} from "../src/ts-mockito";
+import {Bar} from "./utils/Bar";
+
+describe("mocking", () => {
+    let mockedFoo: FooWithProperties;
+    let foo: FooWithProperties;
+
+    describe("mocking object with properties (that don't have getters)", () => {
+        it("does create own property descriptors on mock after when is called", () => {
+            // given
+
+            // when
+            mockedFoo = mock(FooWithProperties);
+            when(mockedFoo.sampleNumber).thenReturn(42);
+
+            // then
+            expect((mockedFoo.sampleNumber as any) instanceof MethodToStub).toBe(true);
+        });
+
+        it("does create own property descriptors on instance", () => {
+            // given
+            mockedFoo = mock(FooWithProperties);
+            foo = instance(mockedFoo);
+
+            // when
+            when(mockedFoo.sampleNumber).thenReturn(42);
+
+            // then
+            expect(foo.sampleNumber).toBe(42);
+        });
+
+        it("works with verification if property is stubbed", () => {
+            // given
+            mockedFoo = mock(FooWithProperties);
+            foo = instance(mockedFoo);
+            when(mockedFoo.sampleNumber).thenReturn(42);
+
+            // when
+            const value = foo.sampleNumber;
+
+            // then
+            expect(() => verify(mockedFoo.sampleNumber).once()).not.toThrow();
+        });
+
+        it("works with verification if property is unstubbed", () => {
+            // given
+            mockedFoo = mock(FooWithProperties);
+            foo = instance(mockedFoo);
+
+            // when
+            const value = foo.sampleNumber;
+
+            // then
+            expect(() => verify(mockedFoo.sampleNumber).once()).not.toThrow();
+        });
+    });
+
+});
+
+class FooWithProperties {
+    public readonly sampleNumber: number;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "declaration": true,
     "lib": [
       "es5",
+      "es6",
       "dom"
     ],
     "types": [


### PR DESCRIPTION
Hi,

with the current implementation it is not possible to mock properties that don't have getters. Trying to do something like `when(mockedFoo.propertyWithoutGetter)` will result in a thrown error.

Since it's not possible to get information about such properties by reflection, my idea was to add property descriptors on demand (if `when` is used). This is done using an es6 Proxy with a catch-all handler intercepting property access on the mock object. 

What do you think about that?

Regards, Markus

Btw.: Thanks for this awesome mocking library :-)