### PR TITLE
add default export

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -116,3 +116,8 @@ export function notNull(): any {
 export function strictEqual(expectedValue: any): Matcher {
     return new StrictEqualMatcher(expectedValue);
 }
+
+// add a default export for intermediate apps
+
+import * as myself from './ts-mockito'; // import this file into itself
+export default myself;

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -117,7 +117,5 @@ export function strictEqual(expectedValue: any): Matcher {
     return new StrictEqualMatcher(expectedValue);
 }
 
-// add a default export for intermediate apps
-
-import * as myself from './ts-mockito'; // import this file into itself
-export default myself;
+import * as mockito from "./ts-mockito";
+export default mockito;


### PR DESCRIPTION
Library as it stands can't be used with `ember-browserify` as it can't handle named exports.

This PR adds a default export alongside the named exports.