### PR TITLE
Solving the problem of accessing a class property when use spy

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -88,7 +88,7 @@ export class Mocker {
                     this.createMethodStub(name);
                     this.createInstanceActionListener(name, obj);
                 } else {
-                    object[name] = descriptor.value;
+                    // no need to reassign properties
                 }
             });
         });

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -83,10 +83,14 @@ export class Mocker {
                 if (descriptor.get) {
                     this.createPropertyStub(name);
                     this.createInstancePropertyDescriptorListener(name, descriptor, obj);
-                } else {
+                    this.createInstanceActionListener(name, obj);
+                } else if(typeof descriptor.value === "function") {
                     this.createMethodStub(name);
+                    this.createInstanceActionListener(name, obj);
                 }
-                this.createInstanceActionListener(name, obj);
+                else {
+                    object[name] = descriptor.value;
+                }
             });
         });
     }

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -84,11 +84,10 @@ export class Mocker {
                     this.createPropertyStub(name);
                     this.createInstancePropertyDescriptorListener(name, descriptor, obj);
                     this.createInstanceActionListener(name, obj);
-                } else if(typeof descriptor.value === "function") {
+                } else if (typeof descriptor.value === "function") {
                     this.createMethodStub(name);
                     this.createInstanceActionListener(name, obj);
-                }
-                else {
+                } else {
                     object[name] = descriptor.value;
                 }
             });

--- a/src/utils/ObjectInspector.ts
+++ b/src/utils/ObjectInspector.ts
@@ -3,7 +3,7 @@ import * as _ from "lodash";
 export class ObjectInspector {
     public getObjectPrototypes(prototype: any): any[] {
         const prototypes: any[] = [];
-        while (_.isObject(prototype) && prototype !== Object.prototype) {
+        while (_.isObject(prototype) && (prototype !== Object.prototype && prototype !== Function.prototype)) {
             prototypes.push(prototype);
             prototype = Object.getPrototypeOf(prototype);
         }

--- a/test/spy.spec.ts
+++ b/test/spy.spec.ts
@@ -17,6 +17,10 @@ describe("spying on a real object", () => {
         }
     }
 
+    function RealFn() {
+
+    }
+
     describe("calling a mocked method", () => {
         it("delegates a call to the mock", () => {
             // given
@@ -69,6 +73,16 @@ describe("spying on a real object", () => {
 
             // then
             expect(foo.bar()).toBe(42);
+        });
+    });
+
+    describe("spying functions", () => {
+        it("should not mock function.prototype methods", () => {
+          // when
+          spy(RealFn);
+
+          expect(RealFn.bind).toBe(Function.prototype.bind);
+          expect(RealFn.apply).toBe(Function.prototype.apply);
         });
     });
 

--- a/test/spy.spec.ts
+++ b/test/spy.spec.ts
@@ -2,6 +2,8 @@ import {capture, reset, spy, verify, when} from "../src/ts-mockito";
 
 describe("spying on a real object", () => {
     class Real {
+        public b = 11;
+
         public foo(a: number) {
             return a;
         }
@@ -67,6 +69,19 @@ describe("spying on a real object", () => {
 
             // then
             expect(foo.bar()).toBe(42);
+        });
+    });
+
+    describe("access to a real object property", () => {
+        it("get instance property", () => {
+          // given
+          const foo = new Real();
+
+          // when
+          spy(foo);
+
+          // then
+          expect(foo.b).toBe(11);
         });
     });
 


### PR DESCRIPTION
This request is linked to #66

I added an object property type check so that the class properties are not treated as methods and now they are accessible from the original method