### PR TITLE
Default export without self import

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -142,5 +142,5 @@ export default {
     notNull,
     strictEqual,
     match,
-    objectContaining
+    objectContaining,
 };

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -117,5 +117,23 @@ export function strictEqual(expectedValue: any): Matcher {
     return new StrictEqualMatcher(expectedValue);
 }
 
-import * as mockito from "./ts-mockito";
-export default mockito;
+// Export default object with all members (ember-browserify doesn't support named exports).
+export default {
+    spy,
+    mock,
+    verify,
+    when,
+    instance,
+    capture,
+    reset,
+    resetCalls,
+    anyOfClass,
+    anyFunction,
+    anyNumber,
+    anyString,
+    anything,
+    between,
+    deepEqual,
+    notNull,
+    strictEqual,
+};

--- a/test/defaultExport.spec.ts
+++ b/test/defaultExport.spec.ts
@@ -1,0 +1,22 @@
+import mockitoDefault from "../src/ts-mockito";
+import {spy} from "../src/ts-mockito";
+import * as asteriskStyleImport from "../src/ts-mockito";
+
+describe("default export", () => {
+    it("is an object", () => {
+        expect(mockitoDefault).toBeDefined();
+        expect(typeof mockitoDefault === "object").toBeTruthy();
+        expect(mockitoDefault).toBe(asteriskStyleImport.default);
+    });
+
+    it("contains proper member functions", () => {
+        expect(typeof mockitoDefault.spy === "function").toBeTruthy();
+        expect(mockitoDefault.spy).toBe(spy);
+    });
+
+    it("contains each module member function", () => {
+        // Asterisk style import contains all member function + the default, so default export should have one
+        // member less.
+        expect(Object.keys(mockitoDefault).length).toBe(Object.keys(asteriskStyleImport).length - 1);
+    });
+});


### PR DESCRIPTION
The self import in the main file causes an exception when bundling the module using rollup. Manually defining a default export object with all exported members fixes the issue. It's not pretty, though.