### PR TITLE
If descriptor contains set property, create mock set property

### DIFF
--- a/test/mocking.getter.spec.ts
+++ b/test/mocking.getter.spec.ts
@@ -75,6 +75,19 @@ describe("mocking", () => {
             // then
         });
     });
+
+    describe("mocking object with getter and setter of same name allows both", () => {
+       it("does not throw assigning value to read only getter when using set property", () => {
+           // given
+           mockedFoo = mock(FooWithGetterAndSetter);
+           foo = instance(mockedFoo);
+
+           // when
+           foo.twoPlusTwo = 7;
+
+           // then
+       });
+    });
 });
 
 abstract class SampleAbstractClass {


### PR DESCRIPTION
I noticed that if a class had a get and a set property with the same name, and you attempted to set to the setter on a mocked instance of the object it would throw an error that the property was a read-only getter. 

I found a solution for the bug by checking the descriptor, and then passing the descriptor through when creating the method stubs to allow the stub to know whether to create just a get, just a set, or both.

If you can see a better solution to resolving this issue let me know and I will update! Thanks for the wonderful library. Has saved many lines of code in my tests.

