### PR TITLE
Adding support for mocking interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@ Mocking library for TypeScript inspired by http://mockito.org/
 ## 1.x to 2.x migration guide
 [1.x to 2.x migration guide](https://github.com/NagRock/ts-mockito/wiki/ts-mockito-1.x-to-2.x-migration-guide)
 
+
 ## Main features
 
 
 * Strongly typed
 * IDE autocomplete
-* Mock creation (`mock`) (also abstract classes) [#example](#basics)
+* Mock creation (`mock`) (also abstract classes and interfaces) [#example](#basics)
 * Spying on real objects (`spy`) [#example](#spying-on-real-objects)
 * Changing mock behavior (`when`) via:
 	* `thenReturn` - return value [#example](#stubbing-method-calls)
@@ -35,7 +36,7 @@ Mocking library for TypeScript inspired by http://mockito.org/
 
 ### Basics
 ``` typescript
-// Creating mock
+// Creating mock from a class
 let mockedFoo:Foo = mock(Foo);
 
 // Getting instance from mock
@@ -49,6 +50,43 @@ foo.getBar(5);
 verify(mockedFoo.getBar(3)).called();
 verify(mockedFoo.getBar(5)).called();
 ```
+
+### Create a mock from an interface
+
+Mocking interfaxces works just the same as mocking classes, except you
+must use the `imock()` function to create the mock.
+
+```typescript
+let mockedFoo:Foo = imock(); // Foo is a typescript interface
+when(mockedFoo.getBar(5)).thenReturn('five');
+```
+
+It also works for properties.
+
+```typescript
+let mockedFoo:Foo = imock();
+when(mockedFoo.bar).thenReturn('five');
+```
+
+For interface mocks, you can set the defauklt behviour for mocked properties that
+have no expectations set. They can behave eiter as a property, returning null, or
+as a function, returning a function that returns null, or throw an exception.
+
+```typescript
+let mockedFoo1:Foo = imock(MockPropertyPolicy.Throw);
+instance(mockedFoo1).bar; // This throws an exception, because there is no expectation set on the bar property
+
+let mockedFoo2:Foo = imock(MockPropertyPolicy.Throw);
+when(mockedFoo2.bar).thenReturn('five');
+instance(mockedFoo2).bar; // Now this returns 'five', and no exception is thrown, because there is an expectation set on the bar property
+
+let mockedFoo3:Foo = imock(MockPropertyPolicy.StubAsProperty);
+instance(mockedFoo3).bar; // This returns null, because no expectation is set
+
+let mockedFoo4:Foo = imock(MockPropertyPolicy.StubAsMethod);
+instance(mockedFoo4).getBar(5); // This returns null, because no expectation is set
+```
+
 
 ### Stubbing method calls
 

--- a/src/MethodStubVerificator.ts
+++ b/src/MethodStubVerificator.ts
@@ -29,7 +29,7 @@ export class MethodStubVerificator<T> {
     }
 
     public times(value: number): void {
-        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.name, this.methodToVerify.matchers);
+        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.methodName, this.methodToVerify.matchers);
         if (value !== allMatchingActions.length) {
             const methodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
             throw new Error(`Expected "${methodToVerifyAsString}to be called ${value} time(s). But has been called ${allMatchingActions.length} time(s).`);
@@ -37,7 +37,7 @@ export class MethodStubVerificator<T> {
     }
 
     public atLeast(value: number): void {
-        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.name, this.methodToVerify.matchers);
+        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.methodName, this.methodToVerify.matchers);
         if (value > allMatchingActions.length) {
             const methodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
             throw new Error(`Expected "${methodToVerifyAsString}to be called at least ${value} time(s). But has been called ${allMatchingActions.length} time(s).`);
@@ -45,7 +45,7 @@ export class MethodStubVerificator<T> {
     }
 
     public atMost(value: number): void {
-        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.name, this.methodToVerify.matchers);
+        const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.methodName, this.methodToVerify.matchers);
         if (value < allMatchingActions.length) {
             const methodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
             throw new Error(`Expected "${methodToVerifyAsString}to be called at least ${value} time(s). But has been called ${allMatchingActions.length} time(s).`);
@@ -53,8 +53,8 @@ export class MethodStubVerificator<T> {
     }
 
     public calledBefore(method: any): void {
-        const firstMethodAction = this.methodToVerify.mocker.getFirstMatchingAction(this.methodToVerify.name, this.methodToVerify.matchers);
-        const secondMethodAction = method.mocker.getFirstMatchingAction(method.name, method.matchers);
+        const firstMethodAction = this.methodToVerify.mocker.getFirstMatchingAction(this.methodToVerify.methodName, this.methodToVerify.matchers);
+        const secondMethodAction = method.mocker.getFirstMatchingAction(method.methodName, method.matchers);
         const mainMethodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
         const secondMethodAsString = this.methodCallToStringConverter.convert(method);
         const errorBeginning = `Expected "${mainMethodToVerifyAsString} to be called before ${secondMethodAsString}`;
@@ -73,8 +73,8 @@ export class MethodStubVerificator<T> {
     }
 
     public calledAfter(method: any): void {
-        const firstMethodAction = this.methodToVerify.mocker.getFirstMatchingAction(this.methodToVerify.name, this.methodToVerify.matchers);
-        const secondMethodAction = method.mocker.getFirstMatchingAction(method.name, method.matchers);
+        const firstMethodAction = this.methodToVerify.mocker.getFirstMatchingAction(this.methodToVerify.methodName  , this.methodToVerify.matchers);
+        const secondMethodAction = method.mocker.getFirstMatchingAction(method.methodName, method.matchers);
         const mainMethodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
         const secondMethodAsString = this.methodCallToStringConverter.convert(method);
         const errorBeginning = `Expected "${mainMethodToVerifyAsString}to be called after ${secondMethodAsString}`;

--- a/src/MethodToStub.ts
+++ b/src/MethodToStub.ts
@@ -6,6 +6,6 @@ export class MethodToStub {
     constructor(public methodStubCollection: MethodStubCollection,
                 public matchers: Matcher[],
                 public mocker: Mocker,
-                public name: string) {
+                public methodName: string) {
     }
 }

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -18,7 +18,9 @@ export class Mocker {
     private mockableFunctionsFinder = new MockableFunctionsFinder();
     private objectPropertyCodeRetriever = new ObjectPropertyCodeRetriever();
 
-    constructor(private clazz: any, protected instance: any = {}) {
+    constructor(private clazz: any, intf: boolean, protected instance: any = {}) {
+        this.mock.__tsmockitoInterface = intf;
+
         this.mock.__tsmockitoInstance = this.instance;
         this.mock.__tsmockitoMocker = this;
         if (_.isObject(this.clazz) && _.isObject(this.instance)) {
@@ -43,8 +45,13 @@ export class Mocker {
             get: (target: any, name: PropertyKey) => {
                 const hasMethodStub = name in target;
                 if (!hasMethodStub) {
-                    this.createPropertyStub(name.toString());
-                    this.createInstancePropertyDescriptorListener(name.toString(), {}, this.clazz.prototype);
+                    if (this.mock.__tsmockitoInterface) {
+                        this.createMethodStub(name.toString());
+                        this.createInstanceActionListener(name.toString(), {});
+                    } else {
+                        this.createPropertyStub(name.toString());
+                        this.createInstancePropertyDescriptorListener(name.toString(), {}, this.clazz.prototype);
+                    }
                 }
                 return target[name];
             },

--- a/src/Spy.ts
+++ b/src/Spy.ts
@@ -8,7 +8,7 @@ export class Spy extends Mocker {
     private realMethods: { [key: string]: RealMethod };
 
     constructor(instance: any) {
-        super(instance.constructor, instance);
+        super(instance.constructor, false, instance);
 
         if (_.isObject(instance)) {
             this.processProperties(instance);

--- a/src/Spy.ts
+++ b/src/Spy.ts
@@ -1,5 +1,5 @@
 import * as _ from "lodash";
-import {Mocker} from "./Mock";
+import {Mocker, MockPropertyPolicy} from "./Mock";
 import {RealMethod} from "./spy/RealMethod";
 import {CallThroughMethodStub} from "./stub/CallThroughMethodStub";
 import {MethodStub} from "./stub/MethodStub";
@@ -8,7 +8,7 @@ export class Spy extends Mocker {
     private realMethods: { [key: string]: RealMethod };
 
     constructor(instance: any) {
-        super(instance.constructor, false, instance);
+        super(instance.constructor, MockPropertyPolicy.StubAsProperty, instance);
 
         if (_.isObject(instance)) {
             this.processProperties(instance);

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -42,7 +42,7 @@ export function imock<T>(): T {
     const mockedValue = new Mocker(Empty, true).getMock();
 
     if (typeof Proxy === "undefined") {
-        return mockedValue;
+        throw new Error("Mocking of interfaces requires support for Proxy objects");
     }
     const tsmockitoMocker = mockedValue.__tsmockitoMocker;
     return new Proxy(mockedValue, tsmockitoMocker.createCatchAllHandlerForRemainingPropertiesWithoutGetters());

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -26,20 +26,22 @@ import {StrictEqualMatcher} from "./matcher/type/StrictEqualMatcher";
 import {MethodStubSetter} from "./MethodStubSetter";
 import {MethodStubVerificator} from "./MethodStubVerificator";
 import {MethodToStub} from "./MethodToStub";
-import {Mocker} from "./Mock";
+import {Mocker, MockPropertyPolicy} from "./Mock";
 import {Spy} from "./Spy";
+
+export {MockPropertyPolicy} from "./Mock";
 
 export function spy<T>(instanceToSpy: T): T {
     return new Spy(instanceToSpy).getMock();
 }
 
-export function mock<T>(clazz: { new(...args: any[]): T; } | (Function & { prototype: T }) ): T {
-    return new Mocker(clazz, false).getMock();
+export function mock<T>(clazz: { new(...args: any[]): T; } | (Function & { prototype: T }), policy: MockPropertyPolicy = MockPropertyPolicy.StubAsProperty ): T {
+    return new Mocker(clazz, policy).getMock();
 }
 
-export function imock<T>(): T {
+export function imock<T>(policy: MockPropertyPolicy = MockPropertyPolicy.StubAsMethod): T {
     class Empty {}
-    const mockedValue = new Mocker(Empty, true).getMock();
+    const mockedValue = new Mocker(Empty, policy).getMock();
 
     if (typeof Proxy === "undefined") {
         throw new Error("Mocking of interfaces requires support for Proxy objects");
@@ -157,4 +159,5 @@ export default {
     strictEqual,
     match,
     objectContaining,
+    MockPropertyPolicy,
 };

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -46,8 +46,8 @@ export function imock<T>(policy: MockPropertyPolicy = MockPropertyPolicy.StubAsM
     if (typeof Proxy === "undefined") {
         throw new Error("Mocking of interfaces requires support for Proxy objects");
     }
-    const tsmockitoMocker = mockedValue.__tsmockitoMocker;
-    return new Proxy(mockedValue, tsmockitoMocker.createCatchAllHandlerForRemainingPropertiesWithoutGetters());
+    const tsmockitoMocker = mockedValue.__tsmockitoMocker as Mocker;
+    return new Proxy(mockedValue, tsmockitoMocker.createCatchAllHandlerForRemainingPropertiesWithoutGetters("expectation"));
 }
 
 export function verify<T>(method: T): MethodStubVerificator<T> {
@@ -78,7 +78,7 @@ export function capture<T0>(method: (a: T0) => any): ArgCaptor1<T0>;
 export function capture(method: (...args: any[]) => any): ArgCaptor {
     const methodStub: MethodToStub = method();
     if (methodStub instanceof MethodToStub) {
-        const actions = methodStub.mocker.getActionsByName(methodStub.name);
+        const actions = methodStub.mocker.getActionsByName(methodStub.methodName);
         return new ArgCaptor(actions);
     } else {
         throw Error("Cannot capture from not mocked object.");

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -34,7 +34,18 @@ export function spy<T>(instanceToSpy: T): T {
 }
 
 export function mock<T>(clazz: { new(...args: any[]): T; } | (Function & { prototype: T }) ): T {
-    return new Mocker(clazz).getMock();
+    return new Mocker(clazz, false).getMock();
+}
+
+export function imock<T>(): T {
+    class Empty {}
+    const mockedValue = new Mocker(Empty, true).getMock();
+
+    if (typeof Proxy === "undefined") {
+        return mockedValue;
+    }
+    const tsmockitoMocker = mockedValue.__tsmockitoMocker;
+    return new Proxy(mockedValue, tsmockitoMocker.createCatchAllHandlerForRemainingPropertiesWithoutGetters());
 }
 
 export function verify<T>(method: T): MethodStubVerificator<T> {
@@ -128,6 +139,7 @@ export function objectContaining(expectedValue: Object): any {
 export default {
     spy,
     mock,
+    imock,
     verify,
     when,
     instance,

--- a/src/utils/MethodCallToStringConverter.ts
+++ b/src/utils/MethodCallToStringConverter.ts
@@ -4,6 +4,6 @@ import {MethodToStub} from "../MethodToStub";
 export class MethodCallToStringConverter {
     public convert(method: MethodToStub): string {
         const stringifiedMatchers = method.matchers.map((matcher: Matcher) => matcher.toString()).join(", ");
-        return `${method.name}(${stringifiedMatchers})" `;
+        return `${method.methodName}(${stringifiedMatchers})" `;
     }
 }

--- a/test/mocking.properties.spec.ts
+++ b/test/mocking.properties.spec.ts
@@ -18,7 +18,10 @@ describe("mocking", () => {
             when(mockedFoo.sampleNumber).thenReturn(42);
 
             // then
-            expect((mockedFoo.sampleNumber as any) instanceof MethodToStub).toBe(true);
+            expect((mockedFoo.sampleNumber as any).methodStubCollection).toBeDefined();
+            expect((mockedFoo.sampleNumber as any).matchers).toBeDefined();
+            expect((mockedFoo.sampleNumber as any).mocker).toBeDefined();
+            expect((mockedFoo.sampleNumber as any).methodName).toBeDefined();
         });
 
         it("does create own property descriptors on instance", () => {

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -157,17 +157,28 @@ describe("mocking", () => {
         let mockedFoo: SampleInterface;
         let foo: SampleInterface;
 
-        it("can create interface mock", () => {
-            // given
+        if (typeof Proxy === "undefined") {
+            it("throws when creating interface mock", () => {
+                // given
 
-            // when
-            mockedFoo = imock();
-            foo = instance(mockedFoo);
+                // when
 
-            // then
-        });
+                // then
+                expect(() => imock()).toThrow();
+            });
+        }
 
         if (typeof Proxy !== "undefined") {
+
+            it("can create interface mock", () => {
+                // given
+
+                // when
+                mockedFoo = imock();
+                foo = instance(mockedFoo);
+
+                // then
+            });
 
             it("can verify call count", () => {
                 // given

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -1,5 +1,5 @@
 import {MethodToStub} from "../src/MethodToStub";
-import {instance, mock, when} from "../src/ts-mockito";
+import {imock, instance, mock, verify, when} from "../src/ts-mockito";
 import {Bar} from "./utils/Bar";
 
 describe("mocking", () => {
@@ -151,6 +151,51 @@ describe("mocking", () => {
             // then
 
         });
+    });
+
+    describe("mocking an interface", () => {
+        let mockedFoo: SampleInterface;
+        let foo: SampleInterface;
+
+        it("can create interface mock", () => {
+            // given
+
+            // when
+            mockedFoo = imock();
+            foo = instance(mockedFoo);
+
+            // then
+        });
+
+        if (typeof Proxy !== "undefined") {
+
+            it("can verify call count", () => {
+                // given
+                mockedFoo = imock();
+                foo = instance(mockedFoo);
+
+                // when
+                const result = foo.sampleMethod();
+
+                // then
+                verify(mockedFoo.sampleMethod()).called();
+                expect(result).toBe(null);
+            });
+
+            it("can setup call actions", () => {
+                // given
+                mockedFoo = imock();
+                foo = instance(mockedFoo);
+                when(mockedFoo.sampleMethod()).thenReturn(5);
+
+                // when
+                const result = foo.sampleMethod();
+
+                // then
+                verify(mockedFoo.sampleMethod()).called();
+                expect(result).toBe(5);
+            });
+        }
     });
 });
 

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -1,5 +1,5 @@
 import {MethodToStub} from "../src/MethodToStub";
-import {imock, instance, mock, verify, when} from "../src/ts-mockito";
+import {imock, instance, mock, MockPropertyPolicy, verify, when} from "../src/ts-mockito";
 import {Bar} from "./utils/Bar";
 
 describe("mocking", () => {
@@ -153,7 +153,7 @@ describe("mocking", () => {
         });
     });
 
-    describe("mocking an interface", () => {
+    describe("mocking an interface with methods", () => {
         let mockedFoo: SampleInterface;
         let foo: SampleInterface;
 
@@ -206,6 +206,85 @@ describe("mocking", () => {
                 verify(mockedFoo.sampleMethod()).called();
                 expect(result).toBe(5);
             });
+
+            it("can return default value from actions with no setup", () => {
+                // given
+                mockedFoo = imock();
+                foo = instance(mockedFoo);
+
+                // when
+                const result = foo.sampleMethod();
+
+                // then
+                verify(mockedFoo.sampleMethod()).called();
+                expect(result).toBe(null);
+            });
+        }
+    });
+
+    describe("mock an interface with properties", () => {
+        let mockedFoo: SamplePropertyInterface;
+        let foo: SamplePropertyInterface;
+
+        if (typeof Proxy !== "undefined") {
+            it("can setup call actions", () => {
+                // given
+                mockedFoo = imock(MockPropertyPolicy.StubAsProperty);
+                foo = instance(mockedFoo);
+                when(mockedFoo.foo).thenReturn("value");
+
+                // when
+                const result = foo.foo;
+
+                // then
+                verify(mockedFoo.foo).called();
+                expect(result).toBe("value");
+            });
+
+            it("can return default value from actions with no setup", () => {
+                // given
+                mockedFoo = imock(MockPropertyPolicy.StubAsProperty);
+                foo = instance(mockedFoo);
+
+                // when
+                const result = foo.foo;
+
+                // then
+                verify(mockedFoo.foo).called();
+                expect(result).toBe(null);
+            });
+        }
+    });
+
+    describe("mock an interface with default policy to throw", () => {
+        let mockedFoo: SamplePropertyInterface;
+        let foo: SamplePropertyInterface;
+
+        if (typeof Proxy !== "undefined") {
+            it("can setup call actions", () => {
+                // given
+                mockedFoo = imock(MockPropertyPolicy.Throw);
+                foo = instance(mockedFoo);
+                when(mockedFoo.foo).thenReturn("value");
+
+                // when
+                const result = foo.foo;
+
+                // then
+                verify(mockedFoo.foo).called();
+                expect(result).toBe("value");
+            });
+
+            it("can throw from actions with no setup", () => {
+                // given
+                mockedFoo = imock(MockPropertyPolicy.Throw);
+                foo = instance(mockedFoo);
+
+                // when
+                expect(() => foo.foo).toThrow();
+
+                // then
+            });
         }
     });
 });
@@ -234,6 +313,11 @@ interface SampleInterface {
     dependency: Bar;
 
     sampleMethod(): number;
+}
+
+interface SamplePropertyInterface {
+    foo: string;
+    bar: number;
 }
 
 class SampleInterfaceImplementation implements SampleInterface {

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -100,7 +100,7 @@ describe("mocking", () => {
             const result = foo.getGenericTypedValue();
 
             // then
-            expect(expectedResult).toEqual(result);
+            expect(result).toEqual(expectedResult);
         });
 
         it("does create own property descriptors on instance", () => {
@@ -223,21 +223,21 @@ describe("mocking", () => {
     });
 
     describe("mock an interface with properties", () => {
-        let mockedFoo: SamplePropertyInterface;
-        let foo: SamplePropertyInterface;
+        let mockedFoo: SampleInterface;
+        let foo: SampleInterface;
 
         if (typeof Proxy !== "undefined") {
             it("can setup call actions", () => {
                 // given
                 mockedFoo = imock(MockPropertyPolicy.StubAsProperty);
                 foo = instance(mockedFoo);
-                when(mockedFoo.foo).thenReturn("value");
+                when(mockedFoo.sampleProperty).thenReturn("value");
 
                 // when
-                const result = foo.foo;
+                const result = foo.sampleProperty;
 
                 // then
-                verify(mockedFoo.foo).called();
+                verify(mockedFoo.sampleProperty).called();
                 expect(result).toBe("value");
             });
 
@@ -247,31 +247,31 @@ describe("mocking", () => {
                 foo = instance(mockedFoo);
 
                 // when
-                const result = foo.foo;
+                const result = foo.sampleProperty;
 
                 // then
-                verify(mockedFoo.foo).called();
+                verify(mockedFoo.sampleProperty).called();
                 expect(result).toBe(null);
             });
         }
     });
 
     describe("mock an interface with default policy to throw", () => {
-        let mockedFoo: SamplePropertyInterface;
-        let foo: SamplePropertyInterface;
+        let mockedFoo: SampleInterface;
+        let foo: SampleInterface;
 
         if (typeof Proxy !== "undefined") {
             it("can setup call actions", () => {
                 // given
                 mockedFoo = imock(MockPropertyPolicy.Throw);
                 foo = instance(mockedFoo);
-                when(mockedFoo.foo).thenReturn("value");
+                when(mockedFoo.sampleProperty).thenReturn("value");
 
                 // when
-                const result = foo.foo;
+                const result = foo.sampleProperty;
 
                 // then
-                verify(mockedFoo.foo).called();
+                verify(mockedFoo.sampleProperty).called();
                 expect(result).toBe("value");
             });
 
@@ -281,9 +281,30 @@ describe("mocking", () => {
                 foo = instance(mockedFoo);
 
                 // when
-                expect(() => foo.foo).toThrow();
+                expect(() => foo.sampleProperty).toThrow();
 
                 // then
+            });
+        }
+    });
+
+    describe("mock an interface with both properties and methods", () => {
+        let mockedFoo: SampleInterface;
+        let foo: SampleInterface;
+
+        if (typeof Proxy !== "undefined") {
+            it("can setup call actions on methods", () => {
+                // given
+                mockedFoo = imock(MockPropertyPolicy.StubAsProperty);
+                foo = instance(mockedFoo);
+                when(mockedFoo.sampleMethod()).thenReturn(5);
+
+                // when
+                const result = foo.sampleMethod();
+
+                // then
+                verify(mockedFoo.sampleMethod()).called();
+                expect(result).toBe(5);
             });
         }
     });
@@ -312,16 +333,15 @@ abstract class SampleAbstractClass {
 interface SampleInterface {
     dependency: Bar;
 
-    sampleMethod(): number;
-}
+    sampleProperty: string;
 
-interface SamplePropertyInterface {
-    foo: string;
-    bar: number;
+    sampleMethod(): number;
 }
 
 class SampleInterfaceImplementation implements SampleInterface {
     public dependency: Bar;
+
+    public sampleProperty: "999";
 
     public sampleMethod(): number {
         return 999;

--- a/test/stubbing.method.spec.ts
+++ b/test/stubbing.method.spec.ts
@@ -1,4 +1,4 @@
-import {anything, instance, mock, when} from "../src/ts-mockito";
+import {anything, imock, instance, mock, when} from "../src/ts-mockito";
 import {Foo} from "./utils/Foo";
 
 describe("mocking", () => {
@@ -213,6 +213,25 @@ describe("mocking", () => {
                     })
                     .catch(err => done.fail(err));
             });
+
+            if (typeof Proxy !== "undefined") {
+                it("resolves with given mock value", done => {
+                    // given
+                    const sampleValue = "abc";
+                    const expectedResult: Foo = imock();
+
+                    when(mockedFoo.sampleMethodReturningObjectPromise(sampleValue)).thenResolve(instance(expectedResult));
+
+                    // when
+                    foo.sampleMethodReturningObjectPromise(sampleValue)
+                        .then(value => {
+                            // then
+                            expect(value).toEqual(instance(expectedResult));
+                            done();
+                        })
+                        .catch(err => done.fail(err));
+                });
+            }
         });
 
         describe("with stubbed promise rejection", () => {

--- a/test/utils/Foo.ts
+++ b/test/utils/Foo.ts
@@ -42,4 +42,8 @@ export class Foo {
     public sampleMethodReturningVoidPromise(value: string): Promise<void> {
         return Promise.resolve();
     }
+
+    public sampleMethodReturningObjectPromise(value: string): Promise<Foo> {
+        return Promise.resolve(this);
+    }
 }


### PR DESCRIPTION
This commit adds support for mocking interfaces, like this:

```js
interface Foo {
  bar(value: string): string;
}

let mockedFoo: Foo = imock();
let foo: Foo = instance(mockedFoo);

when(mockedFoo.bar('a')).thenReturn('b');
```
  