### PR TITLE
Add Promise resolve/reject stubs

### DIFF
--- a/src/MethodStubSetter.ts
+++ b/src/MethodStubSetter.ts
@@ -1,5 +1,7 @@
 import {MethodToStub} from "./MethodToStub";
 import {CallFunctionMethodStub} from "./stub/CallFunctionMethodStub";
+import {RejectPromiseMethodStub} from "./stub/RejectPromiseMethodStub";
+import {ResolvePromiseMethodStub} from "./stub/ResolvePromiseMethodStub";
 import {ReturnValueMethodStub} from "./stub/ReturnValueMethodStub";
 import {ThrowErrorMethodStub} from "./stub/ThrowErrorMethodStub";
 
@@ -27,6 +29,20 @@ export class MethodStubSetter<T> {
 
     public thenCall(func: (...args: any[]) => any): this {
         this.methodToStub.methodStubCollection.add(new CallFunctionMethodStub(this.groupIndex, this.methodToStub.matchers, func));
+        return this;
+    }
+
+    public thenResolve(...rest: any[]): this {
+        rest.forEach(value => {
+            this.methodToStub.methodStubCollection.add(new ResolvePromiseMethodStub(this.groupIndex, this.methodToStub.matchers, value));
+        });
+        return this;
+    }
+
+    public thenReject(...rest: any[]): this {
+        rest.forEach(value => {
+            this.methodToStub.methodStubCollection.add(new RejectPromiseMethodStub(this.groupIndex, this.methodToStub.matchers, value));
+        });
         return this;
     }
 }

--- a/src/MethodStubSetter.ts
+++ b/src/MethodStubSetter.ts
@@ -5,7 +5,7 @@ import {ResolvePromiseMethodStub} from "./stub/ResolvePromiseMethodStub";
 import {ReturnValueMethodStub} from "./stub/ReturnValueMethodStub";
 import {ThrowErrorMethodStub} from "./stub/ThrowErrorMethodStub";
 
-export class MethodStubSetter<T> {
+export class MethodStubSetter<T, ResolveType = void, RejectType = void> {
     private static globalGroupIndex: number = 0;
     private groupIndex: number;
 
@@ -32,14 +32,14 @@ export class MethodStubSetter<T> {
         return this;
     }
 
-    public thenResolve(...rest: any[]): this {
+    public thenResolve(...rest: ResolveType[]): this {
         rest.forEach(value => {
             this.methodToStub.methodStubCollection.add(new ResolvePromiseMethodStub(this.groupIndex, this.methodToStub.matchers, value));
         });
         return this;
     }
 
-    public thenReject(...rest: any[]): this {
+    public thenReject(...rest: RejectType[]): this {
         rest.forEach(value => {
             this.methodToStub.methodStubCollection.add(new RejectPromiseMethodStub(this.groupIndex, this.methodToStub.matchers, value));
         });

--- a/src/stub/RejectPromiseMethodStub.ts
+++ b/src/stub/RejectPromiseMethodStub.ts
@@ -1,0 +1,24 @@
+import {ArgsToMatchersValidator} from "../matcher/ArgsToMatchersValidator";
+import {Matcher} from "../matcher/type/Matcher";
+import {AbstractMethodStub} from "./AbstractMethodStub";
+import {MethodStub} from "./MethodStub";
+
+export class RejectPromiseMethodStub extends AbstractMethodStub implements MethodStub {
+    private validator: ArgsToMatchersValidator = new ArgsToMatchersValidator();
+
+    constructor(protected groupIndex: number, private matchers: Array<Matcher>, private value: any) {
+        super();
+    }
+
+    public isApplicable(args: any[]): boolean {
+        return this.validator.validate(this.matchers, args);
+    }
+
+    public execute(args: any[]): void {
+
+    }
+
+    public getValue(): any {
+        return Promise.reject(this.value);
+    }
+}

--- a/src/stub/ResolvePromiseMethodStub.ts
+++ b/src/stub/ResolvePromiseMethodStub.ts
@@ -1,0 +1,24 @@
+import {ArgsToMatchersValidator} from "../matcher/ArgsToMatchersValidator";
+import {Matcher} from "../matcher/type/Matcher";
+import {AbstractMethodStub} from "./AbstractMethodStub";
+import {MethodStub} from "./MethodStub";
+
+export class ResolvePromiseMethodStub extends AbstractMethodStub implements MethodStub {
+    private validator: ArgsToMatchersValidator = new ArgsToMatchersValidator();
+
+    constructor(protected groupIndex: number, private matchers: Array<Matcher>, private value: any) {
+        super();
+    }
+
+    public isApplicable(args: any[]): boolean {
+        return this.validator.validate(this.matchers, args);
+    }
+
+    public execute(args: any[]): void {
+
+    }
+
+    public getValue(): any {
+        return Promise.resolve(this.value);
+    }
+}

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -41,8 +41,10 @@ export function verify<T>(method: T): MethodStubVerificator<T> {
     return new MethodStubVerificator(method as any);
 }
 
-export function when<T>(method: T): MethodStubSetter<T> {
-    return new MethodStubSetter(method as any);
+export function when<T>(method: Promise<T>): MethodStubSetter<Promise<T>, T, any>;
+export function when<T>(method: T): MethodStubSetter<T>;
+export function when<T>(method: any): any {
+    return new MethodStubSetter(method);
 }
 
 export function instance<T>(mockedValue: T): T {

--- a/test/stubbing.method.spec.ts
+++ b/test/stubbing.method.spec.ts
@@ -158,6 +158,42 @@ describe("mocking", () => {
             });
         });
 
+        describe("with stubbed promise resolve", () => {
+            it("resolves with given value", done => {
+                // given
+                const sampleValue = "abc";
+                const expectedResult = "def";
+                when(mockedFoo.sampleMethodReturningPromise(sampleValue)).thenResolve(expectedResult);
+
+                // when
+                foo.sampleMethodReturningPromise(sampleValue)
+                    .then(value => {
+                        // then
+                        expect(value).toEqual(expectedResult);
+                        done();
+                    })
+                    .catch(err => done.fail(err));
+            });
+        });
+
+        describe("with stubbed promise rejection", () => {
+            it("rejects with given error", done => {
+                // given
+                const sampleValue = "abc";
+                const sampleError = new Error("sampleError");
+                when(mockedFoo.sampleMethodReturningPromise(sampleValue)).thenReject(sampleError);
+
+                // when
+                foo.sampleMethodReturningPromise(sampleValue)
+                    .then(value => done.fail())
+                    .catch(err => {
+                        // then
+                        expect(err.message).toEqual("sampleError");
+                        done();
+                    });
+            });
+        });
+
         describe("with stubbed function call", () => {
             it("calls given function", () => {
                 // given

--- a/test/utils/Foo.ts
+++ b/test/utils/Foo.ts
@@ -34,4 +34,8 @@ export class Foo {
     public sampleMethodWithTwoOptionalArguments(a?: number, b?: number): number {
         return a + b;
     }
+
+    public sampleMethodReturningPromise(value: string): Promise<string> {
+        return Promise.resolve(value);
+    }
 }


### PR DESCRIPTION
This commits adds support for resolving/rejecting promises on asynchronous methods.

Example:
```js
when(mock.fetchData('a')).thenResolve({id: 'a', value: 'hello world'});
when(mock.fetchData('b')).thenReject(new Error('b does not exist'));
```


Motivation:

Without this support, you might try to use `thenReturn()`, like this:
```js
when(mock.fetchData('b')).thenReturn(Promise.reject(new Error('b does not exist')));
```

However, this gives you this error:
```
(node:77288) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): [object Object]
(node:77288) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
This is because the rejected promise is created when the mock is set up, not when the function is actually called. If the call occurs in the next process tick, then you get this error.

A better way to do it is this:
```js
when(mock.fetchData('b')).thenCall(() => Promise.reject(new Error('b does not exist')));
```
Now the promise is created when the method is called, not when it is set up.

This PR adds thenResolve/thenReject, which makes it easier to get these things right the first time, and is also shorter.
  