### PR TITLE
Use import = require syntax to resolve "Circular definition" error with esModuleInterop

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -122,6 +122,6 @@ export function objectContaining(expectedValue: Object): Matcher {
     return new ObjectContainingMatcher(expectedValue);
 }
 
-import * as mockito from "./ts-mockito";
+import mockito = require("./ts-mockito");
 
 export default mockito;


### PR DESCRIPTION
When using typescript 2.7 with `--esModuleInterop`, typescript gives this error when using ts-mockito:
```
node_modules/ts-mockito/lib/ts-mockito.d.ts(39,8): error TS2303: Circular definition of import alias 'mockito'.
```

Switching to the typescript-specific `import = require`-style import fixes this issue and is compatible with the non-esModuleInterop setting as well. It's the same solution that was used to address another interop-related issue in https://github.com/Microsoft/TypeScript/issues/21535

Is there a reason ts-mockito.ts needs to self-import? That seems like it might have other unintended consequences.