### PR TITLE
Replace usage of find & findIndex with other methods to support IE & PhantomJS

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -133,7 +133,7 @@ export class Mocker {
 
     private processClassCode(clazz: any): void {
         const classCode = typeof clazz.toString !== "undefined" ? clazz.toString() : "";
-        const functionNames = this.mockableFunctionsFinder.filter(classCode)[0];
+        const functionNames = this.mockableFunctionsFinder.find(classCode);
         functionNames.forEach((functionName: string) => {
             this.createMethodStub(functionName);
             this.createInstanceActionListener(functionName, this.clazz.prototype);
@@ -143,7 +143,7 @@ export class Mocker {
     private processFunctionsCode(object: any): void {
         this.objectInspector.getObjectPrototypes(object).forEach((obj: any) => {
             this.objectInspector.getObjectOwnPropertyNames(obj).forEach((propertyName: string) => {
-                const functionNames = this.mockableFunctionsFinder.filter(this.objectPropertyCodeRetriever.get(obj, propertyName))[0];
+                const functionNames = this.mockableFunctionsFinder.find(this.objectPropertyCodeRetriever.get(obj, propertyName));
                 functionNames.forEach((functionName: string) => {
                     this.createMethodStub(functionName);
                     this.createInstanceActionListener(functionName, this.clazz.prototype);


### PR DESCRIPTION
After debugging quite a while I have noticed that the mocking does not work with IE & PhantomJS unless there is a polyfill for find and findIndex. I have replaced the occurrences with other methods supported in all browsers.