### PR TITLE
Allow easy regex matching of string arguments

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -112,6 +112,10 @@ export function notNull(): any {
     return new NotNullMatcher() as any;
 }
 
+export function matchString(expectedValue: RegExp | string): any {
+    return new MatchingStringMatcher(expectedValue) as any;
+}
+
 export function strictEqual(expectedValue: any): Matcher {
     return new StrictEqualMatcher(expectedValue);
 }

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -146,6 +146,7 @@ export default {
     between,
     deepEqual,
     notNull,
+    matchString,
     strictEqual,
     match,
     objectContaining,


### PR DESCRIPTION
if you want to mock a function with a string argument, this allows you to use `someFunc(matchString(/regex/i))`. since `match` returns a matcher, it was kind of dirty using `match(/regex/i) as any` all over my tests. All other function matchers return `any` so now string does too. Leaving the original `match` for backwards compatibility though.