### PR TITLE
Fix return types of match()-, objectContaining()- and strictEqual()-m…

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -112,16 +112,16 @@ export function notNull(): any {
     return new NotNullMatcher() as any;
 }
 
-export function strictEqual(expectedValue: any): Matcher {
-    return new StrictEqualMatcher(expectedValue);
+export function strictEqual(expectedValue: any): any {
+    return new StrictEqualMatcher(expectedValue) as any;
 }
 
-export function match(expectedValue: RegExp | string): Matcher {
-    return new MatchingStringMatcher(expectedValue);
+export function match(expectedValue: RegExp | string): any {
+    return new MatchingStringMatcher(expectedValue) as any;
 }
 
-export function objectContaining(expectedValue: Object): Matcher {
-    return new ObjectContainingMatcher(expectedValue);
+export function objectContaining(expectedValue: Object): any {
+    return new ObjectContainingMatcher(expectedValue) as any;
 }
 
 // Export default object with all members (ember-browserify doesn't support named exports).


### PR DESCRIPTION
…atchers

Those matchers have the return type "Matcher" at the moment, but in order to use them in a verfify()-call,
they need "any" or something else that matches the method parameter