### PR TITLE
Adding typing to deepEqual

### DIFF
--- a/src/matcher/type/DeepEqualMatcher.ts
+++ b/src/matcher/type/DeepEqualMatcher.ts
@@ -1,8 +1,8 @@
 import * as _ from "lodash";
 import {Matcher} from "./Matcher";
 
-export class DeepEqualMatcher extends Matcher {
-    constructor(private expectedValue: any) {
+export class DeepEqualMatcher<T> extends Matcher {
+    constructor(private expectedValue: T) {
         super();
     }
 

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -104,8 +104,8 @@ export function between(min: number, max: number): any {
     return new BetweenMatcher(min, max) as any;
 }
 
-export function deepEqual(expectedValue: any): any {
-    return new DeepEqualMatcher(expectedValue);
+export function deepEqual<T>(expectedValue: T): T {
+    return new DeepEqualMatcher<T>(expectedValue) as any;
 }
 
 export function notNull(): any {

--- a/test/matcher/type/DeepEqualMatcher.spec.ts
+++ b/test/matcher/type/DeepEqualMatcher.spec.ts
@@ -1,5 +1,6 @@
+import {DeepEqualMatcher} from "../../../src/matcher/type/DeepEqualMatcher";
 import {Matcher} from "../../../src/matcher/type/Matcher";
-import {anyString, deepEqual} from "../../../src/ts-mockito";
+import {anyString, deepEqual, instance, mock, verify} from "../../../src/ts-mockito";
 
 describe("DeepEqualMatcher", () => {
     describe("checking if two different instances of same number matches", () => {
@@ -7,7 +8,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = 3;
             const secondValue = 3;
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -22,7 +23,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = "sampleString";
             const secondValue = "sampleString";
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -37,7 +38,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = {a: 1, b: {c: 2}};
             const secondValue = {a: 1, b: {c: 2}};
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -52,7 +53,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = {a: 1, b: {c: 2}};
             const secondValue = {a: 1, b: {c: 99999}};
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -67,7 +68,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = {a: 1, b: anyString()};
             const secondValue = {a: 1, b: "2"};
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -80,7 +81,7 @@ describe("DeepEqualMatcher", () => {
             // given
             const firstValue = {a: 1, b: anyString()};
             const secondValue = {a: 1, b: 2};
-            const testObj: Matcher = deepEqual(firstValue);
+            const testObj: Matcher = new DeepEqualMatcher(firstValue);
 
             // when
             const result = testObj.match(secondValue);
@@ -89,4 +90,17 @@ describe("DeepEqualMatcher", () => {
             expect(result).toBeFalsy();
         });
     });
+});
+
+describe("deepEqual", () => {
+  describe("using in verify statements", () => {
+      it("can be used for equality", () => {
+        class Foo {
+          public add = (num1: number, num2: number): number => num1 + num2;
+        }
+        const foo = mock(Foo);
+        instance(foo).add(1, 2);
+        verify(foo.add(deepEqual(1), deepEqual(2))).once();
+      });
+  });
 });


### PR DESCRIPTION
This change allows us to get compiler type errors if someone attempts
to pass in a deepEqual matcher that has the incorrect type. It will
make it simpler to catch test errors earlier.

This is most likely a breaking change, as there may be tests out there
already that will begin to fail to compile, although those tests are
failing at runtime anyway.

See also https://github.com/NagRock/ts-mockito/issues/63