### PR TITLE
Add defer() for testing deferred promise resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,17 @@ when(mockedFoo.fetchData("a")).thenResolve({id: "a", value: "Hello world"});
 when(mockedFoo.fetchData("b")).thenReject(new Error("b does not exist"));
 ```
 
+### Defer resolving promises
+
+The actions `.thenResolve()` and `.thenReject()` are returning promises that are already resolved or rejected. Sometimes you want to control the order or timing of when promises are resolved. In that case it is useful to return a deferred promise, and resolve it from the test code, when appropriate.
+
+```typescript
+let d = defer<number>();
+when(obj.method()).thenReturn(d); // Return a promise that is not resolved yet
+
+d.resolve(1); // Later, the promise is resolved or rejected
+```
+
 ### Resetting mock calls
 
 You can reset just mock call counter

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -123,6 +123,22 @@ export function objectContaining(expectedValue: Object): any {
     return new ObjectContainingMatcher(expectedValue) as any;
 }
 
+export type Deferred<T> = Promise<T> & {
+    resolve: (value: T) => void;
+    reject: (err: any) => void;
+};
+
+export function defer<T>(): Deferred<T> {
+    let resolve: (value: T) => void;
+    let reject: (err: any) => void;
+
+    const d = new Promise<T>((res, rej) => {
+        resolve = res;
+        reject = rej;
+    });
+    return Object.assign(d, { resolve, reject });
+}
+
 // Export default object with all members (ember-browserify doesn't support named exports).
 export default {
     spy,
@@ -144,4 +160,5 @@ export default {
     strictEqual,
     match,
     objectContaining,
+    defer,
 };

--- a/test/defer.spec.ts
+++ b/test/defer.spec.ts
@@ -1,0 +1,35 @@
+import { anything, defer, fnmock, instance, mock, verify, when } from "../src/ts-mockito";
+
+class MockObject {
+    public method(): Promise<number> {
+        return Promise.resolve(100);
+    }
+}
+
+describe("defer", () => {
+    it("resolves a promise", async () => {
+        const resolved: (value: number) => void = fnmock();
+        const obj: MockObject = mock(MockObject);
+        const d = defer<number>();
+        when(obj.method()).thenReturn(d);
+
+        instance(obj).method().then(instance(resolved));
+        verify(resolved(anything())).never();
+
+        d.resolve(1);
+        await verify(resolved(1)).timeout(100);
+    });
+
+    it("rejects a promise", async () => {
+        const rejected: (err: any) => void = fnmock();
+        const obj: MockObject = mock(MockObject);
+        const d = defer<number>();
+        when(obj.method()).thenReturn(d);
+
+        instance(obj).method().catch(instance(rejected));
+        verify(rejected(anything())).never();
+
+        d.reject(1);
+        await verify(rejected(1)).timeout(100);
+    });
+});


### PR DESCRIPTION
Useful utility to defer promise resolution:

```typescript
let d = defer<number>();
when(obj.method()).thenReturn(d); // Return a promise that is not resolved yet

d.resolve(1); // Later, the promise is resolved or rejected
```

Controlling the order in which promises are resolved or rejected is very useful in unit testing, but you should avoid this kind of constructs in production code, and use the `Promise` constructor instead. So this fits very well into a mocking framework. When choosing between using any of the available libraries or to write the few lines of code in `ts-mockito`, I think it is better to add the few lines of code, also since it is easier to document how to perform this kind of test if you don't rely on any other library for the documentation.

The test code does not compile, it depends on these PRs:
 - https://github.com/NagRock/ts-mockito/pull/140
 - https://github.com/NagRock/ts-mockito/pull/97