### PR TITLE
Docs: make getting instance from mocking interface more obvious

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ Mocking interfaces requires `Proxy` implementation
 
 ``` typescript
 let mockedFoo:Foo = mock<FooInterface>(); // instead of mock(FooInterface)
+const foo: SampleGeneric<FooInterface> = instance(mockedFoo);
 ```
 
 ### Mocking types


### PR DESCRIPTION
From #156 