### PR TITLE
120: support set when mocking getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ console.log(foo.sampleGetter);
 
 ### Stubbing property values that have no getters
 
-Syntax is the same as with getter values.
+Syntax is the same as with getter values. If the property has a setter calling the setter will automatically define a ```when``` on the property and the provided value will be returned by subsequent calls to the property. 
 
 Please note, that stubbing properties that don't have getters only works if [Proxy](http://www.ecma-international.org/ecma-262/6.0/#sec-proxy-objects) object is available (ES6).
 

--- a/test/mocking.setter.spec.ts
+++ b/test/mocking.setter.spec.ts
@@ -1,0 +1,99 @@
+import { instance, mock, when } from "../src/ts-mockito";
+
+describe("mocking", () => {
+  let mockedFoo: FooWithGetterAndSetter;
+  let foo: FooWithGetterAndSetter;
+
+  describe("mocking object with getters and setters", () => {
+    it("can mock unknown properties", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+
+      // when
+      mockedFoo["unknownProperty"] = 42;
+      foo = instance(mockedFoo);
+
+      // then
+      expect(foo["unknownProperty"]).toEqual(42);
+    });
+
+    it("does define a when for the getter when a value is set on the mock", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+
+      // when
+      mockedFoo.twoPlusTwo = 42;
+      foo = instance(mockedFoo);
+
+      // then
+      expect(foo.twoPlusTwo).toEqual(42);
+    });
+
+    it("does define a when for the getter when a value is set on the instance", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+
+      // when
+      foo = instance(mockedFoo);
+      foo.twoPlusTwo = 42;
+
+      // then
+      expect(foo.twoPlusTwo).toEqual(42);
+    });
+
+    it("does allow users to supply a new getter value", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+      foo = instance(mockedFoo);
+
+      // when
+      foo.twoPlusTwo = 100;
+      when(mockedFoo.twoPlusTwo).thenReturn(42);
+
+      // then
+      expect(foo.twoPlusTwo).toEqual(42);
+    });
+
+    it("does allow users to set a value on the mock for a property with no getter or setter", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+
+      // when
+      mockedFoo.noGetter = 42;
+      foo = instance(mockedFoo);
+
+      // then
+      expect(foo.noGetter).toEqual(42);
+    });
+
+    it("does allow users to set a value on the instance for a property with no getter or setter", () => {
+      // given
+      mockedFoo = mock(FooWithGetterAndSetter);
+      foo = instance(mockedFoo);
+
+      // when
+      foo.noGetter = 42;
+
+      // then
+      expect(foo.noGetter).toEqual(42);
+    });
+  });
+});
+
+class FooWithGetterAndSetter {
+  public noGetter = 10;
+
+  constructor() {}
+
+  public sampleMethod(): number {
+    return 4;
+  }
+
+  public get twoPlusTwo(): number {
+    return 2;
+  }
+
+  public set twoPlusTwo(value: number) {
+    return;
+  }
+}


### PR DESCRIPTION
I'm pretty sure this wasn't the best way to do it but basically when you have a property on your object you basically cannot test anything that tries to set the property. To get it fixed I added a default implementation for the setter that registers a when for the property with the value just set.

On the plus side it lets you do set and kinda check if it worked by doing a get. On the minus side this is somewhat implicit. I cancelled my previous PR and created a new one with some updates and additional test coverage