### PR TITLE
Fix problem with a mock resolving a mocked value with Promises

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -18,6 +18,7 @@ export class Mocker {
     private mockableFunctionsFinder = new MockableFunctionsFinder();
     private objectPropertyCodeRetriever = new ObjectPropertyCodeRetriever();
     private excludedPropertyNames: string[] = ["hasOwnProperty"];
+    private defaultedPropertyNames: string[] = ["Symbol(Symbol.toPrimitive)", "then", "catch"];
 
     constructor(private clazz: any, public instance: any = {}) {
         this.mock.__tsmockitoInstance = this.instance;
@@ -39,6 +40,9 @@ export class Mocker {
                     const hasMethodStub = name in target;
 
                     if (!hasMethodStub) {
+                        if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
+                            return undefined;
+                        }
                         return this.createActionListener(name.toString());
                     }
                     return target[name];
@@ -64,6 +68,9 @@ export class Mocker {
 
                 const hasMethodStub = name in target;
                 if (!hasMethodStub) {
+                    if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
+                        return undefined;
+                    }
                     this.createMethodStub(name.toString());
                     this.createInstanceActionListener(name.toString(), {});
                 }

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -108,6 +108,18 @@ describe("mocking", () => {
             // then
             expect(thenable.catch()).toEqual("42");
         });
+
+        it("formats as [object Object]", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+
+            // then
+            const str = `"${thenable}"`;
+            expect(str).toEqual('"[object Object]"');
+        });
     });
 
     describe("mocking class with hasOwnProperty", () => {

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -62,6 +62,52 @@ describe("mocking", () => {
             // then
             expect(foo.sampleString).toBe("42");
         });
+
+        it("does not create then() descriptor", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            const woof: any = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(woof.then == null).toBe(true);
+        });
+
+        it("does create then() descriptor", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+            when(mockedThenable.then()).thenReturn("42");
+
+            // then
+            expect(thenable.then()).toEqual("42");
+        });
+
+        it("does not create catch() descriptor", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            const woof: any = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(woof.catch == null).toBe(true);
+        });
+
+        it("does create catch() descriptor", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+            when(mockedThenable.catch()).thenReturn("42");
+
+            // then
+            expect(thenable.catch()).toEqual("42");
+        });
     });
 
     describe("mocking class with hasOwnProperty", () => {
@@ -229,5 +275,15 @@ class SampleGeneric<T> {
 
     public getGenericTypedValue(): T {
         return null;
+    }
+}
+
+abstract class SampleThenable {
+    public then(): string {
+        return "bob";
+    }
+
+    public catch(): string {
+        return "bob";
     }
 }


### PR DESCRIPTION
The long description is in #191 so this is short.

This fixes a problem where returning a mocked object through `thenResolve()` on another mocked object never resolves.