### PR TITLE
Fixed problem with a mock resolving a mocked value with Promises

### DIFF
--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -18,6 +18,7 @@ export class Mocker {
     private mockableFunctionsFinder = new MockableFunctionsFinder();
     private objectPropertyCodeRetriever = new ObjectPropertyCodeRetriever();
     private excludedPropertyNames: string[] = ["hasOwnProperty"];
+    private defaultedPropertyNames: string[] = ["Symbol(Symbol.toPrimitive)", "then", "catch"];
 
     constructor(private clazz: any, public instance: any = {}) {
         this.mock.__tsmockitoInstance = this.instance;
@@ -39,6 +40,9 @@ export class Mocker {
                     const hasMethodStub = name in target;
 
                     if (!hasMethodStub) {
+                        if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
+                            return undefined;
+                        }
                         return this.createActionListener(name.toString());
                     }
                     return target[name];
@@ -64,6 +68,9 @@ export class Mocker {
 
                 const hasMethodStub = name in target;
                 if (!hasMethodStub) {
+                    if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
+                        return undefined;
+                    }
                     this.createMethodStub(name.toString());
                     this.createInstanceActionListener(name.toString(), {});
                 }

--- a/src/Mock.ts
+++ b/src/Mock.ts
@@ -68,9 +68,6 @@ export class Mocker {
 
                 const hasMethodStub = name in target;
                 if (!hasMethodStub) {
-                    if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
-                        return undefined;
-                    }
                     this.createMethodStub(name.toString());
                     this.createInstanceActionListener(name.toString(), {});
                 }
@@ -84,6 +81,9 @@ export class Mocker {
             get: (target: any, name: PropertyKey) => {
                 const hasMethodStub = name in target;
                 if (!hasMethodStub) {
+                    if (this.defaultedPropertyNames.indexOf(name.toString()) >= 0) {
+                        return undefined;
+                    }
                     this.createPropertyStub(name.toString());
                     this.createInstancePropertyDescriptorListener(name.toString(), {}, this.clazz.prototype);
                 }

--- a/test/interface.spec.ts
+++ b/test/interface.spec.ts
@@ -1,26 +1,73 @@
 import { instance, mock, when } from "../src/ts-mockito";
 import { FooInterface } from "./utils/FooInterface";
+import { ThenableInterface } from "./utils/Thenable";
 
 describe("Interface", () => {
-  let mockedFoo: FooInterface;
-  let foo: FooInterface;
-
   if (typeof Proxy === "undefined") {
     pending("Testing browser doesn't support Proxy.");
   }
 
-  beforeEach(() => {
-    mockedFoo = mock<FooInterface>();
-    foo = instance(mockedFoo);
+  describe("Basic", () => {
+    let mockedFoo: FooInterface;
+    let foo: FooInterface;
+
+    beforeEach(() => {
+      mockedFoo = mock<FooInterface>();
+      foo = instance(mockedFoo);
+    });
+
+    it("should mock interface function", () => {
+      // Rest cases for interfaces are tested in verification.spec.ts
+
+      // when
+      when(mockedFoo.sumByInterface(2, 3)).thenReturn(1000);
+
+      // then
+      expect(foo.sumByInterface(2, 3)).toEqual(1000);
+    });
   });
+  describe("Promise", () => {
+    let mockedThen: ThenableInterface;
+    let inst: ThenableInterface;
 
-  it("should mock interface function", () => {
-    // Rest cases for interfaces are tested in verification.spec.ts
+    beforeEach(() => {
+      mockedThen = mock<ThenableInterface>();
+      inst = instance(mockedThen);
+    });
 
-    // when
-    when(mockedFoo.sumByInterface(2, 3)).thenReturn(1000);
+    it("does not create then descriptor for interface", () => {
+      // given
 
-    // then
-    expect(foo.sumByInterface(2, 3)).toEqual(1000);
+      // when
+
+      // then
+      expect(inst.then).toBeUndefined();
+    });
+    it("creates then descriptor for interface", () => {
+      // given
+
+      // when
+      when(mockedThen.then()).thenReturn("woof");
+
+      // then
+      expect(inst.then).toBeDefined();
+    });
+    it("does not create catch descriptor for interface", () => {
+      // given
+
+      // when
+
+      // then
+      expect(inst.catch).toBeUndefined();
+    });
+    it("creates catch descriptor for interface", () => {
+      // given
+
+      // when
+      when(mockedThen.catch()).thenReturn("woof");
+
+      // then
+      expect(inst.catch).toBeDefined();
+    });
   });
 });

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -1,6 +1,7 @@
-import {MethodToStub} from "../src/MethodToStub";
-import {instance, mock, when} from "../src/ts-mockito";
-import {Bar} from "./utils/Bar";
+import { MethodToStub } from "../src/MethodToStub";
+import { instance, mock, when } from "../src/ts-mockito";
+import { Bar } from "./utils/Bar";
+import { ThenableClass } from "./utils/Thenable";
 
 describe("mocking", () => {
     describe("mocking abstract class", () => {
@@ -62,62 +63,63 @@ describe("mocking", () => {
             // then
             expect(foo.sampleString).toBe("42");
         });
-
-        it("does not create then() descriptor", () => {
+    });
+    describe("mocking promise methods", () => {
+        it("does not create then descriptor for class", () => {
             // given
-            mockedFoo = mock(SampleAbstractClass);
-            const woof: any = instance(mockedFoo);
+            const mocked = mock(SampleAbstractClass);
+            const inst = instance(mocked);
 
             // when
 
             // then
-            expect(woof.then == null).toBe(true);
+            expect((inst as any).then).toBeUndefined();
         });
 
-        it("does create then() descriptor", () => {
+        it("does create then descriptor", () => {
             // given
-            const mockedThenable = mock(SampleThenable);
-            const thenable = instance(mockedThenable);
+            const mocked = mock(ThenableClass);
+            const inst = instance(mocked);
 
             // when
-            when(mockedThenable.then()).thenReturn("42");
+            when(mocked.then()).thenReturn("42");
 
             // then
-            expect(thenable.then()).toEqual("42");
+            expect(inst.then()).toEqual("42");
         });
 
-        it("does not create catch() descriptor", () => {
+        it("does not create catch descriptor", () => {
             // given
-            mockedFoo = mock(SampleAbstractClass);
-            const woof: any = instance(mockedFoo);
+            const mocked = mock(SampleAbstractClass);
+            const inst = instance(mocked);
 
             // when
 
             // then
-            expect(woof.catch == null).toBe(true);
+            expect((inst as any).catch).toBeUndefined();
         });
 
-        it("does create catch() descriptor", () => {
+        it("does create catch descriptor", () => {
             // given
-            const mockedThenable = mock(SampleThenable);
-            const thenable = instance(mockedThenable);
+            const mocked = mock(ThenableClass);
+            const inst = instance(mocked);
 
             // when
-            when(mockedThenable.catch()).thenReturn("42");
+            when(mocked.catch()).thenReturn("42");
 
             // then
-            expect(thenable.catch()).toEqual("42");
+            expect(inst.catch()).toEqual("42");
         });
 
-        it("formats as [object Object]", () => {
+        it("default object formatting works", () => {
             // given
-            const mockedThenable = mock(SampleThenable);
-            const thenable = instance(mockedThenable);
+            const mocked = mock(ThenableClass);
+            const inst = instance(mocked);
 
             // when
 
             // then
-            const str = `"${thenable}"`;
+            const str = `"${inst}"`;
             expect(str).toEqual('"[object Object]"');
         });
     });
@@ -287,15 +289,5 @@ class SampleGeneric<T> {
 
     public getGenericTypedValue(): T {
         return null;
-    }
-}
-
-abstract class SampleThenable {
-    public then(): string {
-        return "bob";
-    }
-
-    public catch(): string {
-        return "bob";
     }
 }

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -108,6 +108,18 @@ describe("mocking", () => {
             // then
             expect(thenable.catch()).toEqual("42");
         });
+
+        it("formats as [object Object]", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+
+            // then
+            const str = `"${thenable}"`;
+            expect(str).toEqual('"[object Object]"');
+        });
     });
 
     describe("mocking class with hasOwnProperty", () => {

--- a/test/mocking.types.spec.ts
+++ b/test/mocking.types.spec.ts
@@ -62,6 +62,52 @@ describe("mocking", () => {
             // then
             expect(foo.sampleString).toBe("42");
         });
+
+        it("does not create then() descriptor", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            const woof: any = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(woof.then == null).toBe(true);
+        });
+
+        it("does create then() descriptor", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+            when(mockedThenable.then()).thenReturn("42");
+
+            // then
+            expect(thenable.then()).toEqual("42");
+        });
+
+        it("does not create catch() descriptor", () => {
+            // given
+            mockedFoo = mock(SampleAbstractClass);
+            const woof: any = instance(mockedFoo);
+
+            // when
+
+            // then
+            expect(woof.catch == null).toBe(true);
+        });
+
+        it("does create catch() descriptor", () => {
+            // given
+            const mockedThenable = mock(SampleThenable);
+            const thenable = instance(mockedThenable);
+
+            // when
+            when(mockedThenable.catch()).thenReturn("42");
+
+            // then
+            expect(thenable.catch()).toEqual("42");
+        });
     });
 
     describe("mocking class with hasOwnProperty", () => {
@@ -229,5 +275,15 @@ class SampleGeneric<T> {
 
     public getGenericTypedValue(): T {
         return null;
+    }
+}
+
+abstract class SampleThenable {
+    public then(): string {
+        return "bob";
+    }
+
+    public catch(): string {
+        return "bob";
     }
 }

--- a/test/utils/Thenable.ts
+++ b/test/utils/Thenable.ts
@@ -1,0 +1,15 @@
+export abstract class ThenableClass {
+  public then(): string {
+    return "bob";
+  }
+
+  public catch(): string {
+    return "bob";
+  }
+}
+
+export interface ThenableInterface {
+  then(): string;
+
+  catch(): string;
+}


### PR DESCRIPTION
The long description is in #191 so this is short.

This is a replacement for #192 which was incorrect.

This fixes a problem where returning a mocked object through thenResolve() on another mocked object never resolves.