### PR TITLE
Remove warning message from Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   "jest": {
     "testEnvironment": "node",
     "transform": {
-      "^.+\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.ts$": "ts-jest"
     },
     "testRegex": "(/__tests__/.*|\\.(spec))\\.(ts|js)$",
     "moduleFileExtensions": [


### PR DESCRIPTION
When running the tests, Jest writes out this message many times:

ts-jest[main] (WARN) Replace any occurrences of "ts-jest/dist/preprocessor.js" or \
 "<rootDir>/node_modules/ts-jest/preprocessor.js" in the 'transform' \
 section of your Jest config with just "ts-jest".

This just does what the message says and changes the full path to
just ts-jest.