### PR TITLE
Allow any type as method stub rejections.

### DIFF
--- a/src/MethodStubSetter.ts
+++ b/src/MethodStubSetter.ts
@@ -5,7 +5,7 @@ import {ResolvePromiseMethodStub} from "./stub/ResolvePromiseMethodStub";
 import {ReturnValueMethodStub} from "./stub/ReturnValueMethodStub";
 import {ThrowErrorMethodStub} from "./stub/ThrowErrorMethodStub";
 
-export class MethodStubSetter<T, ResolveType = void, RejectType = Error> {
+export class MethodStubSetter<T, ResolveType = void, RejectType = any> {
     private static globalGroupIndex: number = 0;
     private groupIndex: number;
 
@@ -47,13 +47,10 @@ export class MethodStubSetter<T, ResolveType = void, RejectType = Error> {
         return this;
     }
 
-    public thenReject(...rest: Error[]): this {
+    public thenReject(...rest: RejectType[]): this {
         this.convertToPropertyIfIsNotAFunction();
-        // Resolves undefined if no resolve values are given.
-        if (rest.length === 0) {
-            rest.push(new Error(`mocked '${this.methodToStub.name}' rejected`));
-        }
-        rest.forEach(value => {
+        const rejections: any[] = rest.length === 0 ? [new Error(`mocked '${this.methodToStub.name}' rejected`)] : rest;
+        rejections.forEach(value => {
             this.methodToStub.methodStubCollection.add(new RejectPromiseMethodStub(this.groupIndex, this.methodToStub.matchers, value));
         });
         return this;

--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -42,7 +42,7 @@ export function verify<T>(method: T): MethodStubVerificator<T> {
     return new MethodStubVerificator(method as any);
 }
 
-export function when<T>(method: Promise<T>): MethodStubSetter<Promise<T>, T, Error>;
+export function when<T>(method: Promise<T>): MethodStubSetter<Promise<T>, T, any>;
 export function when<T>(method: T): MethodStubSetter<T>;
 export function when<T>(method: any): any {
     return new MethodStubSetter(method);

--- a/test/stubbing.method.spec.ts
+++ b/test/stubbing.method.spec.ts
@@ -232,6 +232,23 @@ describe("mocking", () => {
                     });
             });
 
+            it("rejects with given anything", done => {
+                // given
+                const sampleValue = "abc";
+                const sampleRejection = "myErrorType";
+                const a = when(mockedFoo.sampleMethodReturningPromise(sampleValue));
+                a.thenReject(sampleRejection);
+
+                // when
+                foo.sampleMethodReturningPromise(sampleValue)
+                    .then(value => done.fail())
+                    .catch(err => {
+                        // then
+                        expect(err).toEqual(sampleRejection);
+                        done();
+                    });
+            });
+
             describe("But without defined error", () => {
                 it("rejects with default error", done => {
                     // given


### PR DESCRIPTION
Reverted the restrictions from version 2.4.0 again: All types (not only `Error` types) are possible as method rejections.
See #150 