### PR TITLE
objectContaining matcher to output object representation when a test fails

### DIFF
--- a/src/matcher/type/ObjectContainingMatcher.ts
+++ b/src/matcher/type/ObjectContainingMatcher.ts
@@ -11,6 +11,6 @@ export class ObjectContainingMatcher extends Matcher {
     }
 
     public toString(): string {
-        return `objectContaining(${this.expectedValue})`;
+        return `objectContaining(${JSON.stringify(this.expectedValue)})`;
     }
 }

--- a/test/matcher/type/ObjectContainingMatcher.spec.ts
+++ b/test/matcher/type/ObjectContainingMatcher.spec.ts
@@ -24,12 +24,49 @@ describe("ObjectContainingMatcher", () => {
         });
 
         describe("when given value doesn't contain given object", () => {
-            it("returns false", () => {
-                // when
-                const result = testObj.match({b: {c: "c"}});
+            describe("when given value is an object", () => {
+                it("returns false", () => {
+                    // when
+                    const result = testObj.match({b: {c: "c"}});
 
-                // then
-                expect(result).toBeFalsy();
+                    // then
+                    expect(result).toBeFalsy();
+                });
+
+                it("represents the object as a json string", () => {
+                    // when
+                    const result = testObj.toString();
+
+                    // then
+                    expect(result).toContain(`objectContaining({"b":{"c":"c","d":{}}`);
+                });
+            });
+
+            describe("when given value is a scalar", () => {
+                const testCases = [
+                    { scalar: 123, expected: 123 },
+                    { scalar: 123.456, expected: 123.456 },
+                    { scalar: "a", expected: '"a"' },
+                ];
+
+                testCases.forEach(test => {
+                    it(`represents the scalar value '${test.scalar}' as string`, () => {
+                        // when
+                        const testValue: Matcher = objectContaining(test.scalar);
+                        const result = testValue.toString();
+
+                        // then
+                        expect(result).toContain(`objectContaining(${test.expected})`);
+                    });
+
+                    it("returns false", () => {
+                        // when
+                        const result = testObj.match(test.scalar);
+
+                        // then
+                        expect(result).toBeFalsy();
+                    });
+                });
             });
         });
     });


### PR DESCRIPTION
Currently, when passing in an object with objectContaining which does not match the given value, the matcher's toString() method will return the object as an [object Object] representation. I modified the matcher and tests to be able to include the object's representation for easier debugging.

Given this code example:
![code-example](https://user-images.githubusercontent.com/650192/90566446-7e534b80-e176-11ea-8020-046e902c442e.png)

Using objectContaining with an object that does not match will output this:
![objectContaining](https://user-images.githubusercontent.com/650192/90566046-d2a9fb80-e175-11ea-8bc8-af0254f685f4.png)

And with the fix:
![objectContaining-with-fix](https://user-images.githubusercontent.com/650192/90566216-1ac91e00-e176-11ea-9bf8-17bd3a3fa555.png)
