### PR TITLE
Added anything() to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ foo.getBar(5);
 
 // Explicit, readable verification
 verify(mockedFoo.getBar(3)).called();
-verify(mockedFoo.getBar(5)).called();
+verify(mockedFoo.getBar(anything())).called();
 ```
 
 ### Stubbing method calls
@@ -110,9 +110,9 @@ foo.getBar(3);
 verify(mockedFoo.getBar(1)).once();               // was called with arg === 1 only once
 verify(mockedFoo.getBar(2)).twice();              // was called with arg === 2 exactly two times
 verify(mockedFoo.getBar(between(2, 3))).thrice(); // was called with arg between 2-3 exactly three times
-verify(mockedFoo.getBar(anyNumber()).times(4);     // was called with any number arg exactly four times
+verify(mockedFoo.getBar(anyNumber()).times(4);    // was called with any number arg exactly four times
 verify(mockedFoo.getBar(2)).atLeast(2);           // was called with arg === 2 min two times
-verify(mockedFoo.getBar(1)).atMost(1);           // was called with arg === 1 max one time
+verify(mockedFoo.getBar(anything())).atMost(4);   // was called with any argument max one time
 verify(mockedFoo.getBar(4)).never();              // was never called with arg === 4
 ```
 


### PR DESCRIPTION
I recently started using this package, and I spent some time figuring out the proper way to check for calls with any arguments. I think adding `anything()` to the readme, especially the "Basics" fragment would be very helpful for new users of this package.