### PR TITLE
Fixes byCallIndex error messages

### DIFF
--- a/src/capture/ArgCaptor.ts
+++ b/src/capture/ArgCaptor.ts
@@ -25,10 +25,10 @@ export class ArgCaptor {
     }
 
     public byCallIndex(index: number): any {
-        if (index >= this.actions.length) {
-            throw new Error(`Cannot capture arguments, method has not been called so many times: ${index + 1}`);
+        if (this.actions.length > index && index >= 0) {
+            return this.actions[index].args;
         }
-        return this.actions[index].args;
+        throw new Error(`Cannot capture arguments, method has not been called so many times: ${index + 1}`);
     }
 }
 


### PR DESCRIPTION
If index was less 0 (in the case of calling last() on a captured method that had not been called at all), a TypeError ('last' of undefined) would be thrown.