### PR TITLE
Added better verification message

### DIFF
--- a/src/MethodStubVerificator.ts
+++ b/src/MethodStubVerificator.ts
@@ -32,7 +32,9 @@ export class MethodStubVerificator<T> {
         const allMatchingActions = this.methodToVerify.mocker.getAllMatchingActions(this.methodToVerify.name, this.methodToVerify.matchers);
         if (value !== allMatchingActions.length) {
             const methodToVerifyAsString = this.methodCallToStringConverter.convert(this.methodToVerify);
-            throw new Error(`Expected "${methodToVerifyAsString}to be called ${value} time(s). But has been called ${allMatchingActions.length} time(s).`);
+            const msg = `Expected "${methodToVerifyAsString}to be called ${value} time(s). But has been called ${allMatchingActions.length} time(s).`;
+            throw new Error(`${msg}
+${this.actualCalls()}`);
         }
     }
 
@@ -90,5 +92,11 @@ export class MethodStubVerificator<T> {
         } else {
             throw new Error(`${errorBeginning}but none of them has been called.`);
         }
+    }
+
+    private actualCalls() {
+        const calls = this.methodToVerify.mocker.getActionsByName(this.methodToVerify.name);
+        return `Actual calls:
+  ${this.methodCallToStringConverter.convertActualCalls(calls).join("\n  ")}`;
     }
 }

--- a/src/utils/MethodCallToStringConverter.ts
+++ b/src/utils/MethodCallToStringConverter.ts
@@ -1,9 +1,14 @@
 import {Matcher} from "../matcher/type/Matcher";
+import {MethodAction} from "../MethodAction";
 import {MethodToStub} from "../MethodToStub";
 
 export class MethodCallToStringConverter {
     public convert(method: MethodToStub): string {
         const stringifiedMatchers = method.matchers.map((matcher: Matcher) => matcher.toString()).join(", ");
         return `${method.name}(${stringifiedMatchers})" `;
+    }
+
+    public convertActualCalls(calls: MethodAction[]): string[] {
+        return calls.map(call => `${call.methodName}(${call.args.map(arg => arg.toString()).join(", ")})`);
     }
 }

--- a/test/verification.spec.ts
+++ b/test/verification.spec.ts
@@ -784,6 +784,24 @@ cases.forEach(testData => {
                 });
             });
         });
+
+        describe("matcher error messages", () => {
+            it("should describe expected method call", () => {
+                instance(mockedFoo).getStringById(2);
+
+                try {
+                    // when
+                    verify(mockedFoo.getStringById(1)).once();
+
+                    expect(true).toBe(false); // Above call should throw an exception
+                } catch (e) {
+                    // then
+                    expect(e.message).toContain("Expected \"getStringById(strictEqual(1))\" to be called 1 time(s). But has been called 0 time(s).\n");
+                    expect(e.message).toContain("Actual calls:\n");
+                    expect(e.message).toContain("getStringById(2)");
+                }
+            });
+        });
     });
 });
 


### PR DESCRIPTION
Duplicated a feature from @johanblumenbergs fork into ts-mockito.
Shows a better log message on verify failures to explain the actual calls that were made

Example
![image](https://user-images.githubusercontent.com/6642457/124335409-18a35e80-db92-11eb-9888-9fb42afeeafb.png)
