### PR TITLE
Upgrade Lodash  

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "typescript": "^4.3.5"
   },
   "dependencies": {
-    "lodash": "^4.17.5"
+    "lodash": "^4.17.21"
   },
   "resolutions": {
     "write-file-atomic": "2.4.1"


### PR DESCRIPTION
lodash versions prior to 4.17.21 are vulnerable to Command Injection via the template function.

[CVE-2021-23337](https://github.com/advisories/GHSA-35jh-r3h4-6jhm)
