### PR TITLE
Add an “expect nothing” call to verify

### DIFF
--- a/src/ts-mockito.ts
+++ b/src/ts-mockito.ts
@@ -39,6 +39,9 @@ export function mock<T>(clazz?: any): T {
 }
 
 export function verify<T>(method: T): MethodStubVerificator<T> {
+    if ('expect' in globalThis && 'nothing' in expect()) {
+        expect().nothing();
+    }
     return new MethodStubVerificator(method as any);
 }
 


### PR DESCRIPTION
This fixes the warning/error of jasmine that a test has no expectations.

See https://github.com/NagRock/ts-mockito/issues/128.