### PR TITLE
Added new examples to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Mocking library for TypeScript inspired by http://mockito.org/
 
 ## Main features
 
-
 * Strongly typed
 * IDE autocomplete
 * Mock creation (`mock`) (also abstract classes) [#example](#basics)
@@ -26,6 +25,7 @@ Mocking library for TypeScript inspired by http://mockito.org/
 * Capturing arguments passed to method (`capture`) [#example](#capturing-method-arguments)
 * Recording multiple behaviors [#example](#recording-multiple-behaviors)
 * Readable error messages (ex. `'Expected "convertNumberToString(strictEqual(3))" to be called 2 time(s). But has been called 1 time(s).'`)
+* Mocking within other functions [#example](#mocking-within-other-functions)
 
 ## Installation
 
@@ -83,6 +83,22 @@ let foo:Foo = instance(mockedFoo);
 
 // prints three
 console.log(foo.sampleGetter);
+```
+
+in th case that your getter returns an object, make sure that you return the expected object rather than trying to access its properties from within `when`:
+
+``` typescript
+// Creating mock
+let mockedFoo:Foo = mock(Foo);
+
+// stub getter before execution
+when(mockedFoo.sampleGetter).thenReturn({ name: 'three' });
+
+// Getting instance
+let foo:Foo = instance(mockedFoo);
+
+// prints three
+console.log(foo.sampleGetter.name);
 ```
 
 ### Stubbing property values that have no getters
@@ -363,6 +379,24 @@ const spiedFoo = spy(foo);
 foo.bar();
 
 console.log(capture(spiedFoo.bar).last()); // [42] 
+```
+
+### Mocking within other functions
+
+To mock class objects within other functions, it works exactly the same as mocking outside of functions
+
+``` typescript
+const baz = () => {
+    const foo = new Foo();
+    return foo.getBar(1);
+}
+
+const mockedFoo = mock(Foo);
+when(mockedFoo.getBar(1)).thenReturn(5);
+
+console.log(baz()); // 5
+
+verify(mockedFoo.getBar(1)).once();
 ```
 
 ### Thanks


### PR DESCRIPTION
# Summary

As a user of this library, I thought these additions to the documentation would be useful for any first-time user to know when using `ts-mockito`. These are:

- **Being careful with testing getters that return class objects:** I found this out later with my team the hard way when we realized that you can't access properties of getters within `when`. Retrospectively, this makes a ton of sense, but at the time we would keep getting this obscure error that didn't really explain what was going on. I think adding this example would just be a good heads up for anyone that might encounter the same issue down the line.
- **Mocking objects within functions:** I think this is one of the most important features for most, and if you are somebody who is looking for this kind of solution for the first time, having a clear statement saying: "You can in fact mock class object functionalities within other functions without much hassle" would make users look no further.

These changes aren't game changing for users who already know what they're looking for, or understand the underlying functinoalities of the library. I made them more for users like me when we stumbled across this library for the first time looking for an easy and elgant solution. `ts-mockito` is where it's at, and I think these clarifications could be helpful in the long run :)